### PR TITLE
Jewel fixes - Monitors and OSDs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -49,6 +49,7 @@ suites:
     - "recipe[ceph-chef::mon]"
     - "recipe[ceph-chef::mon_start]"
     - "recipe[ceph-chef::mon_bootstrap_peer_hint]"
+    - "recipe[ceph-chef::mon_keys]"
   attributes: *defaults
 - name: mds
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,6 +30,7 @@ suites:
   attributes: &defaults
     ceph:
       version: jewel
+      search_by_environment: true
       config:
         fsid: ae3f1d03-bacd-4a90-b869-1a4fabb107f2
       network:
@@ -47,6 +48,7 @@ suites:
   run_list:
     - "recipe[ceph-chef::mon]"
     - "recipe[ceph-chef::mon_start]"
+    - "recipe[ceph-chef::mon_bootstrap_peer_hint]"
   attributes: *defaults
 - name: mds
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,8 +1,12 @@
 ---
 driver_plugin: vagrant
 driver_config:
-  vagrantfile_erb: test/integration/Vagrantfile.erb
+  # vagrantfile_erb: test/integration/Vagrantfile.erb
   require_chef_omnibus: true
+
+driver:
+  network:
+    - [ "private_network", { ip: "192.168.33.33" } ]
 
 platforms:
 - name: ubuntu-14.04
@@ -11,7 +15,7 @@ platforms:
   attributes:
     apache:
       mpm: event        # ugly workaround for onehealth-cookbooks/apache2 #236
-- name: centos-7.1
+- name: centos-7.2
 - name: rhel-7.1
 - name: fedora-22
 
@@ -25,15 +29,24 @@ suites:
     - "recipe[ceph-chef]"
   attributes: &defaults
     ceph:
+      version: jewel
       config:
         fsid: ae3f1d03-bacd-4a90-b869-1a4fabb107f2
+      network:
+        cluster:
+          cidr:
+            - 192.168.33.0/24
+        public:
+          cidr:
+            - 192.168.33.0/24
 - name: osd
   run_list:
     - "role[ceph-osd]"
   attributes: *defaults
 - name: mon
   run_list:
-    - "role[ceph-mon]"
+    - "recipe[ceph-chef::mon]"
+    - "recipe[ceph-chef::mon_start]"
   attributes: *defaults
 - name: mds
   run_list:
@@ -56,4 +69,4 @@ suites:
         - { device: "/dev/sdd" }
   run_list:
     - recipe[ceph-chef::all_in_one]
-    - recipe[ceph_chef_test::cephfs]
+    - recipe[ceph_test::cephfs]

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata
 

--- a/Berksfile
+++ b/Berksfile
@@ -5,5 +5,5 @@ metadata
 group :integration do
   cookbook 'apt'
   cookbook 'yum'
-  cookbook 'ceph_chef_test', path: 'test/cookbooks/ceph_chef_test'
+  # cookbook 'ceph_chef_test', path: 'test/cookbooks/ceph_test'
 end

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This cookbook can be used to implement a chosen cluster design. Most of the conf
 * `node['ceph']['config]'['global']['cluster network']` - a CIDR specification of a separate cluster replication network
 * `node['ceph']['config]'['global']['rgw dns name']` -  the main domain of the radosgw daemon
 
-Most notably, the configuration does **NOT** need to set the `mon initial members`, because the cookbook does a node search based on TAGS to find other mons in the same environment. However, you can add them to `node['ceph']['config']['global']['mon initial members'] = <whatever mon ip list you want>`
+Most notably, the configuration does **NOT** need to set the `mon initial members`, because the cookbook does a node search based on TAGS or ENVIRONMENTS to find other mons in the same environment. However, you can add them to `node['ceph']['config']['global']['mon initial members'] = <whatever mon ip list you want>`
 
 The other set of attributes that this recipe needs is `node['ceph']['osd']['devices']`, which is an array of OSD definitions, similar to the following:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,16 +38,14 @@ default['ceph']['init_style'] = case node['platform']
                                   'sysvinit'
                                 end
 
-# NOTE: If the version is greater than 'hammer' then change owner and group to 'ceph'
-case default['ceph']['version']
-when 'hammer'
+default['ceph']['owner'] = 'ceph'
+default['ceph']['group'] = 'ceph'
+default['ceph']['mode'] = 0o0750
+
+# NOTE: If the version is 'hammer' then change owner and group to 'root'
+if node['ceph']['version'] == 'hammer'
   default['ceph']['owner'] = 'root'
   default['ceph']['group'] = 'root'
-  default['ceph']['mode'] = 0o0755
-else
-  default['ceph']['owner'] = 'ceph'
-  default['ceph']['group'] = 'ceph'
-  default['ceph']['mode'] = 0o0750
 end
 
 # Override these in your environment file or here if you wish. Don't put them in the 'ceph''config''global' section.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,7 +53,7 @@ end
 default['ceph']['network']['public']['cidr'] = ['10.121.1.0/24']
 default['ceph']['network']['cluster']['cidr'] = ['10.121.2.0/24']
 
-# Tags are used to identify nodes for searching.
+# Tags are used to identify nodes for searching (unless using environments - see below)
 # IMPORTANT
 default['ceph']['admin']['tag'] = 'ceph-admin'
 default['ceph']['radosgw']['tag'] = 'ceph-rgw'
@@ -62,6 +62,12 @@ default['ceph']['rbd']['tag'] = 'ceph-rbd'
 default['ceph']['osd']['tag'] = 'ceph-osd'
 default['ceph']['mds']['tag'] = 'ceph-mds'
 default['ceph']['restapi']['tag'] = 'ceph-restapi'
+
+# Search by environment
+# Setting this to true will search for nodes by environment/attributes instead of roles/tags.
+# By default, the environment searched is the value of `node.environment`, though this can
+# be overriden by setting `node['ceph']['search_environment']` to the desired environment.
+default['ceph']['search_by_environment'] = false
 
 # Set the max pid since Ceph creates a lot of threads and if using with OpenStack then...
 default['ceph']['system']['sysctls'] = ['kernel.pid_max=4194303', 'fs.file-max=26234859']

--- a/files/centos/ceph-mon@.service
+++ b/files/centos/ceph-mon@.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=(overriden) Ceph cluster monitor daemon
+
+# According to:
+#   http://www.freedesktop.org/wiki/Software/systemd/NetworkTarget
+# these can be removed once ceph-mon will dynamically change network
+# configuration.
+After=network-online.target local-fs.target time-sync.target
+Wants=network-online.target local-fs.target time-sync.target
+
+PartOf=ceph-mon.target
+
+[Service]
+LimitNOFILE=1048576
+LimitNPROC=1048576
+EnvironmentFile=-/etc/sysconfig/ceph
+Environment=CLUSTER=ceph
+ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecReload=/bin/kill -HUP $MAINPID
+PrivateDevices=yes
+ProtectHome=true
+ProtectSystem=full
+PrivateTmp=true
+TasksMax=infinity
+Restart=on-failure
+StartLimitInterval=30min
+StartLimitBurst=3
+
+[Install]
+WantedBy=ceph-mon.target

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,6 +11,7 @@ depends 'apt'
 depends 'yum', '>= 3.8.1'
 depends 'yum-epel'
 depends 'poise', '>= 2.5.0'
+depends 'chef-sugar', '>= 3.3.0'
 
 supports 'ubuntu', '>= 14.04'
 supports 'redhat', '>= 7.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cjones303@bloomberg.net'
 license 'Apache v2.0'
 description 'Installs/Configures Ceph (Jewel and above)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.9'
+version '1.0.10'
 
 depends	'apache2', '>= 1.1.12'
 depends 'apt'

--- a/recipes/bootstrap_osd_key.rb
+++ b/recipes/bootstrap_osd_key.rb
@@ -1,0 +1,47 @@
+
+# Create a new bootstrap-osd secret key if it does not exist either on disk as node attribtues
+bash 'create-bootstrap-osd-key' do
+  code <<-EOH
+    BOOTSTRAP_KEY=$(ceph --name mon. --keyring /etc/ceph/#{node['ceph']['cluster']}.mon.keyring auth get-or-create-key client.bootstrap-osd mon 'allow profile bootstrap-osd')
+    ceph-authtool "/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring" \
+        --create-keyring \
+        --name=client.bootstrap-osd \
+        --add-key="$BOOTSTRAP_KEY"
+  EOH
+  not_if { ceph_chef_bootstrap_osd_secret }
+  not_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
+  notifies :create, 'ruby_block[save_bootstrap_osd]', :immediately
+  sensitive true if Chef::Resource::Execute.method_defined? :sensitive
+end
+
+# If the bootstrap-osd secret key exists as a node attribute but not on disk, write it out
+execute 'format bootstrap-osd-secret as keyring' do
+  command lazy { "ceph-authtool '/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring' --create-keyring --name=client.bootstrap-osd --add-key=#{ceph_chef_bootstrap_osd_secret}" }
+  only_if { ceph_chef_bootstrap_osd_secret }
+  not_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
+  sensitive true if Chef::Resource::Execute.method_defined? :sensitive
+end
+
+# If the bootstrap-osd secret key exists on disk but not as a node attribute, save it as an attribute
+ruby_block 'check_bootstrap_osd' do
+  block do
+    true
+  end
+  notifies :create, 'ruby_block[save_bootstrap_osd]', :immediately
+  not_if { ceph_chef_bootstrap_osd_secret }
+  only_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
+end
+
+# Save the bootstrap-osd secret key to the node attributes. This is typically performed
+# as a notification following the create step, but you can set:
+#   node['ceph']['monitor-secret'] = ceph_chef_keygen()
+# in a higher level recipe to force a specific value
+ruby_block 'save_bootstrap_osd' do
+  block do
+    fetch = Mixlib::ShellOut.new("ceph-authtool '/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring' --print-key --name=client.bootstrap-osd")
+    fetch.run_command
+    key = fetch.stdout
+    ceph_chef_save_bootstrap_osd_secret(key.delete!("\n"))
+  end
+  action :nothing
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include_recipe 'chef-sugar::default'
+
 include_recipe 'ceph-chef::repo' if node['ceph']['install_repo']
 include_recipe 'ceph-chef::conf'
 
@@ -49,4 +51,10 @@ end
 
 if node['ceph']['pools']['radosgw']['federated_enable']
   ceph_chef_build_federated_pool('radosgw')
+end
+
+execute 'ceph-systemctl-daemon-reload' do
+  command 'systemctl daemon-reload'
+  action :nothing
+  only_if { systemd? }
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,17 +33,18 @@ end
 # has been bootstrapped with Chef - /opt/chef/embedded/bin/gem install --force --local /tmp/netaddr-1.5.1.gem
 # Of course, this means you have downloaded the gem from: https://rubygems.org/downloads/netaddr-1.5.1.gem and then
 # copied it to your /tmp directory.
-chef_gem 'netaddr' do
+chef_gem 'netaddr-local' do
+  package_name 'netaddr'
   source '/tmp/netaddr-1.5.1.gem'
   action :install
   compile_time true
-  only_if 'test -f /tmp/netaddr-1.5.1.gem'
+  only_if { File.exist?('/tmp/netaddr-1.5.1.gem') }
 end
 
 chef_gem 'netaddr' do
   action :install
   compile_time true
-  not_if 'test -f /tmp/netaddr-1.5.1.gem'
+  not_if { File.exist?('/tmp/netaddr-1.5.1.gem') }
 end
 
 if node['ceph']['pools']['radosgw']['federated_enable']

--- a/recipes/mon_keys.rb
+++ b/recipes/mon_keys.rb
@@ -24,52 +24,8 @@
 # This recipe can only be ran AFTER a monitor has started
 # NOTE: This recipe will create bootstrap keys for OSD, [MDS, RGW automatically]
 
-# Create a new bootstrap-osd secret key if it does not exist either on disk as node attribtues
-bash 'create-bootstrap-osd-key' do
-  code <<-EOH
-    BOOTSTRAP_KEY=$(ceph --name mon. --keyring /etc/ceph/#{node['ceph']['cluster']}.mon.keyring auth get-or-create-key client.bootstrap-osd mon 'allow profile bootstrap-osd')
-    ceph-authtool "/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring" \
-        --create-keyring \
-        --name=client.bootstrap-osd \
-        --add-key="$BOOTSTRAP_KEY"
-  EOH
-  not_if { ceph_chef_bootstrap_osd_secret }
-  not_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
-  notifies :create, 'ruby_block[save_bootstrap_osd]', :immediately
-  sensitive true if Chef::Resource::Execute.method_defined? :sensitive
-end
-
-# If the bootstrap-osd secret key exists as a node attribute but not on disk, write it out
-execute 'format bootstrap-osd-secret as keyring' do
-  command lazy { "ceph-authtool '/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring' --create-keyring --name=client.bootstrap-osd --add-key=#{ceph_chef_bootstrap_osd_secret}" }
-  only_if { ceph_chef_bootstrap_osd_secret }
-  not_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
-  sensitive true if Chef::Resource::Execute.method_defined? :sensitive
-end
-
-# If the bootstrap-osd secret key exists on disk but not as a node attribute, save it as an attribute
-ruby_block 'check_bootstrap_osd' do
-  block do
-    true
-  end
-  notifies :create, 'ruby_block[save_bootstrap_osd]', :immediately
-  not_if { ceph_chef_bootstrap_osd_secret }
-  only_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
-end
-
-# Save the bootstrap-osd secret key to the node attributes. This is typically performed
-# as a notification following the create step, but you can set:
-#   node['ceph']['monitor-secret'] = ceph_chef_keygen()
-# in a higher level recipe to force a specific value
-ruby_block 'save_bootstrap_osd' do
-  block do
-    fetch = Mixlib::ShellOut.new("ceph-authtool '/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring' --print-key --name=client.bootstrap-osd")
-    fetch.run_command
-    key = fetch.stdout
-    ceph_chef_save_bootstrap_osd_secret(key.delete!("\n"))
-  end
-  action :nothing
-end
+# Create/save/etc the bootstrap-osd key
+include_recipe 'ceph-chef::bootstrap_osd_key'
 
 # # IF the bootstrap key for bootstrap-rgw exists then save it so it's available if wanted later. All bootstrap
 # # keys are created during this recipe process!

--- a/recipes/mon_keys.rb
+++ b/recipes/mon_keys.rb
@@ -47,8 +47,11 @@ execute 'format bootstrap-osd-secret as keyring' do
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
-# If the bootstrap-osd exists on disk but not as a node attribute, save it as an attribute
+# If the bootstrap-osd secret key exists on disk but not as a node attribute, save it as an attribute
 ruby_block 'check_bootstrap_osd' do
+  block do
+    true
+  end
   notifies :create, 'ruby_block[save_bootstrap_osd]', :immediately
   not_if { ceph_chef_bootstrap_osd_secret }
   only_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"

--- a/recipes/mon_keys.rb
+++ b/recipes/mon_keys.rb
@@ -24,19 +24,10 @@
 # This recipe can only be ran AFTER a monitor has started
 # NOTE: This recipe will create bootstrap keys for OSD, [MDS, RGW automatically]
 
-# NOTE: MAY NEED TO MOVE Key gen to it's own recipe for all keys in the /tmp directory for Jewel and later...
-execute 'format bootstrap-osd-secret as keyring' do
-  command lazy { "ceph-authtool '/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring' --create-keyring --name=client.bootstrap-osd --add-key=#{ceph_chef_bootstrap_osd_secret}" }
-  only_if { ceph_chef_bootstrap_osd_secret }
-  not_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
-  sensitive true if Chef::Resource::Execute.method_defined? :sensitive
-end
-
-# NOTE: Don't want to do any 'ceph' calls until a quorum has been established or the ceph-create-keys python script will sit in a constant wait state...
-# BOOTSTRAP_KEY=`ceph --name mon. --keyring /etc/ceph/#{node['ceph']['cluster']}.mon.keyring auth get-or-create-key client.bootstrap-osd mon 'allow profile bootstrap-osd'`
-bash 'save-bootstrap-osd-key' do
+# Create a new bootstrap-osd secret key if it does not exist either on disk as node attribtues
+bash 'create-bootstrap-osd-key' do
   code <<-EOH
-    BOOTSTRAP_KEY=$(ceph-authtool "/etc/ceph/#{node['ceph']['cluster']}.mon.keyring" -n mon. -p)
+    BOOTSTRAP_KEY=$(ceph --name mon. --keyring /etc/ceph/#{node['ceph']['cluster']}.mon.keyring auth get-or-create-key client.bootstrap-osd mon 'allow profile bootstrap-osd')
     ceph-authtool "/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring" \
         --create-keyring \
         --name=client.bootstrap-osd \
@@ -48,8 +39,25 @@ bash 'save-bootstrap-osd-key' do
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
-# Part of monitor-secret calls above - Also, you can set node['ceph']['monitor-secret'] = ceph_chef_keygen()
-# in a higher level recipe like the way ceph-chef does it in ceph-mon.rb
+# If the bootstrap-osd secret key exists as a node attribute but not on disk, write it out
+execute 'format bootstrap-osd-secret as keyring' do
+  command lazy { "ceph-authtool '/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring' --create-keyring --name=client.bootstrap-osd --add-key=#{ceph_chef_bootstrap_osd_secret}" }
+  only_if { ceph_chef_bootstrap_osd_secret }
+  not_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
+  sensitive true if Chef::Resource::Execute.method_defined? :sensitive
+end
+
+# If the bootstrap-osd exists on disk but not as a node attribute, save it as an attribute
+ruby_block 'check_bootstrap_osd' do
+  notifies :create, 'ruby_block[save_bootstrap_osd]', :immediately
+  not_if { ceph_chef_bootstrap_osd_secret }
+  only_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
+end
+
+# Save the bootstrap-osd secret key to the node attributes. This is typically performed
+# as a notification following the create step, but you can set:
+#   node['ceph']['monitor-secret'] = ceph_chef_keygen()
+# in a higher level recipe to force a specific value
 ruby_block 'save_bootstrap_osd' do
   block do
     fetch = Mixlib::ShellOut.new("ceph-authtool '/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring' --print-key --name=client.bootstrap-osd")
@@ -60,41 +68,29 @@ ruby_block 'save_bootstrap_osd' do
   action :nothing
 end
 
-# Make sure the bootstrap-osd key is set for the node. Could have a wrapper move the file to the correct place but the var is not set.
-ruby_block 'check_bootstrap_osd' do
-  block do
-    fetch = Mixlib::ShellOut.new("ceph-authtool '/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring' --print-key --name=client.bootstrap-osd")
-    fetch.run_command
-    key = fetch.stdout
-    ceph_chef_save_bootstrap_osd_secret(key.delete!("\n"))
-  end
-  not_if { ceph_chef_bootstrap_osd_secret }
-  only_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
-end
-
-# IF the bootstrap key for bootstrap-rgw exists then save it so it's available if wanted later. All bootstrap
-# keys are created during this recipe process!
-ruby_block 'save_bootstrap_rgw' do
-  block do
-    fetch = Mixlib::ShellOut.new("ceph-authtool '/var/lib/ceph/bootstrap-rgw/#{node['ceph']['cluster']}.keyring' --print-key --name=client.bootstrap-rgw")
-    fetch.run_command
-    key = fetch.stdout
-    ceph_chef_save_bootstrap_rgw_secret(key.delete!("\n"))
-  end
-  not_if { ceph_chef_bootstrap_rgw_secret }
-  only_if "test -f /var/lib/ceph/bootstrap-rgw/#{node['ceph']['cluster']}.keyring"
-  ignore_failure true
-end
-
-# IF the bootstrap key for bootstrap-mds exists then save it so it's available if wanted later
-ruby_block 'save_bootstrap_mds' do
-  block do
-    fetch = Mixlib::ShellOut.new("ceph-authtool '/var/lib/ceph/bootstrap-mds/#{node['ceph']['cluster']}.keyring' --print-key --name=client.bootstrap-mds")
-    fetch.run_command
-    key = fetch.stdout
-    ceph_chef_save_bootstrap_mds_secret(key.delete!("\n"))
-  end
-  not_if { ceph_chef_bootstrap_mds_secret }
-  only_if "test -f /var/lib/ceph/bootstrap-mds/#{node['ceph']['cluster']}.keyring"
-  ignore_failure true
-end
+# # IF the bootstrap key for bootstrap-rgw exists then save it so it's available if wanted later. All bootstrap
+# # keys are created during this recipe process!
+# ruby_block 'save_bootstrap_rgw' do
+#   block do
+#     fetch = Mixlib::ShellOut.new("ceph-authtool '/var/lib/ceph/bootstrap-rgw/#{node['ceph']['cluster']}.keyring' --print-key --name=client.bootstrap-rgw")
+#     fetch.run_command
+#     key = fetch.stdout
+#     ceph_chef_save_bootstrap_rgw_secret(key.delete!("\n"))
+#   end
+#   not_if { ceph_chef_bootstrap_rgw_secret }
+#   only_if "test -f /var/lib/ceph/bootstrap-rgw/#{node['ceph']['cluster']}.keyring"
+#   ignore_failure true
+# end
+#
+# # IF the bootstrap key for bootstrap-mds exists then save it so it's available if wanted later
+# ruby_block 'save_bootstrap_mds' do
+#   block do
+#     fetch = Mixlib::ShellOut.new("ceph-authtool '/var/lib/ceph/bootstrap-mds/#{node['ceph']['cluster']}.keyring' --print-key --name=client.bootstrap-mds")
+#     fetch.run_command
+#     key = fetch.stdout
+#     ceph_chef_save_bootstrap_mds_secret(key.delete!("\n"))
+#   end
+#   not_if { ceph_chef_bootstrap_mds_secret }
+#   only_if "test -f /var/lib/ceph/bootstrap-mds/#{node['ceph']['cluster']}.keyring"
+#   ignore_failure true
+# end

--- a/recipes/mon_start.rb
+++ b/recipes/mon_start.rb
@@ -50,4 +50,10 @@ else
   end
 end
 
+service 'ceph-mon' do
+  service_name "ceph-mon@#{node['hostname']}"
+  action [:enable, :start]
+  only_if { systemd? }
+end
+
 # Can include mon_bootstrap_peer_hint recipe here or include it in roles after mon_install.

--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -95,54 +95,7 @@ if node['ceph']['version'] == 'hammer'
   end
 end
 
-execute 'osd-create-key-mon-client-in-directory' do
-  command lazy { "ceph-authtool /etc/ceph/#{node['ceph']['cluster']}.mon.keyring --create-keyring --name=mon. --add-key=#{ceph_chef_mon_secret} --cap mon 'allow *'" }
-  not_if "test -f /etc/ceph/#{node['ceph']['cluster']}.mon.keyring"
-end
-
-execute 'osd-create-key-admin-client-in-directory' do
-  command lazy { "ceph-authtool /etc/ceph/#{node['ceph']['cluster']}.client.admin.keyring --create-keyring --name=client.admin --add-key=#{ceph_chef_admin_secret} --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *'" }
-  not_if "test -f /etc/ceph/#{node['ceph']['cluster']}.client.admin.keyring"
-end
-
-# Verifies or sets the correct mode only
-file "/etc/ceph/#{node['ceph']['cluster']}.client.admin.keyring" do
-  mode '0644'
-end
-
-execute 'osd-create-key-bootstrap-in-directory' do
-  command lazy { "ceph-authtool /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring --create-keyring --name=client.bootstrap-osd --add-key=#{ceph_chef_bootstrap_osd_secret}" }
-  # NOTE: If the keyring exists then skip even if the node['bootstrap-osd'] ('ceph_chef_bootstrap_osd_secret') is not empty because you can also copy from other osd node or a central place where may keep keyring files. Just depends on your environment.
-  not_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
-  only_if { ceph_chef_bootstrap_osd_secret }
-end
-
-# BOOTSTRAP_KEY=`ceph --name mon. --keyring '/etc/ceph/#{node['ceph']['cluster']}.mon.keyring' auth get-or-create-key client.bootstrap-osd mon 'allow profile bootstrap-osd'`
-bash 'osd-write-bootstrap-osd-key' do
-  code <<-EOH
-    BOOTSTRAP_KEY=$(ceph-authtool "/etc/ceph/#{node['ceph']['cluster']}.mon.keyring" -n mon. -p)
-    ceph-authtool "/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring" \
-        --create-keyring \
-        --name=client.bootstrap-osd \
-        --add-key="$BOOTSTRAP_KEY"
-  EOH
-  # NOTE: If the keyring exists then skip even if the node['bootstrap-osd'] ('ceph_chef_bootstrap_osd_secret') is empty because you can also copy from other osd node or a central place where may keep keyring files. Just depends on your environment.
-  not_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
-  not_if { ceph_chef_bootstrap_osd_secret }
-  notifies :create, 'ruby_block[save_bootstrap_osd_key]', :immediately
-end
-
-# Blocks like this are used in many places so as to save the values that are generated from bash commands like the one
-# above. The saved value may be used later in other recipes.
-ruby_block 'save_bootstrap_osd_key' do
-  block do
-    fetch = Mixlib::ShellOut.new("ceph-authtool /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring --print-key")
-    fetch.run_command
-    key = fetch.stdout
-    ceph_chef_save_bootstrap_osd_secret(key.delete!("\n"))
-  end
-  action :nothing
-end
+include_recipe 'ceph-chef::bootstrap_osd_key'
 
 # Calling ceph-disk prepare is sufficient for deploying an OSD
 # After ceph-disk prepare finishes, the new device will be caught

--- a/recipes/rpm.rb
+++ b/recipes/rpm.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include_recipe 'yum-epel::default'
+
 platform_family = node['platform_family']
 
 # Setup key so it doesn't have to pull it down

--- a/recipes/rpm.rb
+++ b/recipes/rpm.rb
@@ -37,7 +37,7 @@ end
 # If you use Ceph with no access to the outside world and use RHEL Satellite server then MAKE sure this value is set to false!
 # Otherwise, 'ceph.repo' will be created and your install will eventually timeout with an error.
 yum_repository 'ceph' do
-  name "Ceph #{platform_family} #{node['ceph']['version']} #{branch}"
+  description "Ceph #{platform_family} #{node['ceph']['version']} #{branch}"
   baseurl node['ceph'][platform_family][branch]['repository']
   gpgkey node['ceph'][platform_family][branch]['repository_key']
   only_if { node['ceph']['repo']['create'] }

--- a/recipes/rpm.rb
+++ b/recipes/rpm.rb
@@ -36,11 +36,11 @@ end
 
 # If you use Ceph with no access to the outside world and use RHEL Satellite server then MAKE sure this value is set to false!
 # Otherwise, 'ceph.repo' will be created and your install will eventually timeout with an error.
-if node['ceph']['repo']['create']
-  yum_repository 'ceph' do
-    baseurl node['ceph'][platform_family][branch]['repository']
-    gpgkey node['ceph'][platform_family][branch]['repository_key']
-  end
+yum_repository 'ceph' do
+  name "Ceph #{platform_family} #{node['ceph']['version']} #{branch}"
+  baseurl node['ceph'][platform_family][branch]['repository']
+  gpgkey node['ceph'][platform_family][branch]['repository_key']
+  only_if { node['ceph']['repo']['create'] }
 end
 
 package 'parted'    # needed by ceph-disk-prepare to run partprobe


### PR DESCRIPTION
A series of fixes for jewel to allow a cluster build of monitors and OSDs. This builds on #45.

I'm sure this isn't all of the changes required for Jewel support, but I was able to build a cluster with it consisting of just monitors and OSDs on CentOS 7.2.

This adds a new attribute/feature to handle finding nodes using environments/attributes in addition to roles/tags (`node['ceph']['search_by_environment']`). This defaults to false, so the original behavior is maintained.

Fixes #31 
