### PR TITLE
Remove calling executables with sudo

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cjones303@bloomberg.net'
 license 'Apache v2.0'
 description 'Installs/Configures Ceph (Jewel and above)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.13'
+version '1.0.14'
 
 depends	'apache2', '>= 1.1.12'
 depends 'apt'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -19,6 +19,6 @@
 
 # No need to set the /etc/ceph directory
 # execute 'change-ceph-conf-perm' do
-#  command lazy { "sudo chown #{node['ceph']['owner']}:#{node['ceph']['group']} -R /etc/ceph" }
+#  command lazy { "chown #{node['ceph']['owner']}:#{node['ceph']['group']} -R /etc/ceph" }
 #  ignore_failure true
 # end

--- a/recipes/osd_start_all.rb
+++ b/recipes/osd_start_all.rb
@@ -46,12 +46,12 @@ else
     end
 
     execute 'ceph-osd-start' do
-      command lazy { 'sudo service ceph start osd' }
+      command lazy { 'service ceph start osd' }
       action :run
     end
 
     execute 'ceph-osd-restart' do
-      command lazy { 'sudo service ceph restart osd' }
+      command lazy { 'service ceph restart osd' }
       action :nothing
       subscribes :run, "template[/etc/ceph/#{node['ceph']['cluster']}.conf]"
     end

--- a/recipes/radosgw_federated.rb
+++ b/recipes/radosgw_federated.rb
@@ -60,7 +60,7 @@ if node['ceph']['pools']['radosgw']['federated_enable']
     new_key = ''
     ruby_block "check-radosgw-secret-#{inst['name']}" do
       block do
-        fetch = Mixlib::ShellOut.new("sudo ceph auth get-key client.radosgw.#{inst['region']}-#{inst['name']} 2>/dev/null")
+        fetch = Mixlib::ShellOut.new("ceph auth get-key client.radosgw.#{inst['region']}-#{inst['name']} 2>/dev/null")
         fetch.run_command
         key = fetch.stdout
         unless key.to_s.strip.empty?
@@ -76,14 +76,14 @@ if node['ceph']['pools']['radosgw']['federated_enable']
       new_key = nil if new_key.to_s.strip.length != 40
     end
     execute 'update-ceph-radosgw-secret' do
-      command lazy { "sudo ceph-authtool #{keyring} --name=client.radosgw.#{inst['region']}-#{inst['name']} --add-key=#{new_key} --cap osd 'allow rwx' --cap mon 'allow rwx'" }
+      command lazy { "ceph-authtool #{keyring} --name=client.radosgw.#{inst['region']}-#{inst['name']} --add-key=#{new_key} --cap osd 'allow rwx' --cap mon 'allow rwx'" }
       only_if { !new_key.to_s.strip.empty? }
       only_if "test -f #{keyring}"
       sensitive true if Chef::Resource::Execute.method_defined? :sensitive
     end
 
     execute 'write-ceph-radosgw-secret' do
-      command lazy { "sudo ceph-authtool #{keyring} --create-keyring --name=client.radosgw.#{inst['region']}-#{inst['name']} --add-key=#{new_key} --cap osd 'allow rwx' --cap mon 'allow rwx'" }
+      command lazy { "ceph-authtool #{keyring} --create-keyring --name=client.radosgw.#{inst['region']}-#{inst['name']} --add-key=#{new_key} --cap osd 'allow rwx' --cap mon 'allow rwx'" }
       only_if { !new_key.to_s.strip.empty? }
       not_if "test -f #{keyring}"
       sensitive true if Chef::Resource::Execute.method_defined? :sensitive
@@ -92,7 +92,7 @@ if node['ceph']['pools']['radosgw']['federated_enable']
     # If no initial key exists then this will run
     execute 'generate-client-radosgw-secret' do
       command <<-EOH
-        sudo ceph-authtool --create-keyring #{keyring} -n client.radosgw.#{inst['region']}-#{inst['name']} --gen-key --cap osd 'allow rwx' --cap mon 'allow rwx'
+        ceph-authtool --create-keyring #{keyring} -n client.radosgw.#{inst['region']}-#{inst['name']} --gen-key --cap osd 'allow rwx' --cap mon 'allow rwx'
       EOH
       creates keyring
       not_if { ceph_chef_radosgw_inst_secret("#{inst['region']}-#{inst['name']}") }
@@ -104,15 +104,15 @@ if node['ceph']['pools']['radosgw']['federated_enable']
     # Allow all zone keys
     execute 'update-client-radosgw-secret' do
       command <<-EOH
-        sudo ceph-authtool #{keyring} -n client.radosgw.#{inst['region']}-#{inst['name']} --gen-key --cap osd 'allow rwx' --cap mon 'allow rwx'
+        ceph-authtool #{keyring} -n client.radosgw.#{inst['region']}-#{inst['name']} --gen-key --cap osd 'allow rwx' --cap mon 'allow rwx'
       EOH
-      not_if "sudo grep client.radosgw.#{inst['region']}-#{inst['name']} #{keyring}"
+      not_if "grep client.radosgw.#{inst['region']}-#{inst['name']} #{keyring}"
       sensitive true if Chef::Resource::Execute.method_defined? :sensitive
     end
 
     execute "update-client-radosgw-#{inst['region']}-#{inst['name']}-auth" do
       command <<-EOH
-        sudo ceph -k #{base_key} auth add client.radosgw.#{inst['region']}-#{inst['name']} -i #{keyring}
+        ceph -k #{base_key} auth add client.radosgw.#{inst['region']}-#{inst['name']} -i #{keyring}
       EOH
       not_if "ceph auth list | grep client.radosgw.#{inst['region']}-#{inst['name']}"
       sensitive true if Chef::Resource::Execute.method_defined? :sensitive
@@ -121,7 +121,7 @@ if node['ceph']['pools']['radosgw']['federated_enable']
     # Saves the key to the current node attribute
     ruby_block "save-radosgw-secret-#{inst['name']}" do
       block do
-        fetch = Mixlib::ShellOut.new("sudo ceph-authtool #{keyring} -n client.radosgw.#{inst['region']}-#{inst['name']}  --print-key")
+        fetch = Mixlib::ShellOut.new("ceph-authtool #{keyring} -n client.radosgw.#{inst['region']}-#{inst['name']}  --print-key")
         fetch.run_command
         key = fetch.stdout
         ceph_chef_save_radosgw_inst_secret(key.delete!("\n"), "#{inst['region']}-#{inst['name']}")
@@ -194,16 +194,16 @@ if node['ceph']['pools']['radosgw']['federated_enable']
 
       execute "region-set-#{inst['region']}" do
         command <<-EOH
-          sudo radosgw-admin region set --infile #{region_file} --rgw-region #{region} --name client.radosgw.#{inst['region']}-#{inst['name']}
+          radosgw-admin region set --infile #{region_file} --rgw-region #{region} --name client.radosgw.#{inst['region']}-#{inst['name']}
         EOH
-        # not_if "sudo radosgw-admin region list --name client.radosgw.#{inst['region']}-#{inst['name']} | grep #{inst['region']}"
+        # not_if "radosgw-admin region list --name client.radosgw.#{inst['region']}-#{inst['name']} | grep #{inst['region']}"
       end
 
       execute "region-map-set-#{inst['region']}" do
         command <<-EOH
-          sudo radosgw-admin region-map set --infile #{region_map_file} --rgw-region #{region} --name client.radosgw.#{inst['region']}-#{inst['name']}
+          radosgw-admin region-map set --infile #{region_map_file} --rgw-region #{region} --name client.radosgw.#{inst['region']}-#{inst['name']}
         EOH
-        # not_if "sudo radosgw-admin region-map get --name client.radosgw.#{inst['region']}-#{inst['name']} | grep #{inst['region']}"
+        # not_if "radosgw-admin region-map get --name client.radosgw.#{inst['region']}-#{inst['name']} | grep #{inst['region']}"
       end
 
       # execute 'remove-default-region' do
@@ -220,22 +220,22 @@ if node['ceph']['pools']['radosgw']['federated_enable']
 
       execute "zone-set-#{inst['name']}" do
         command <<-EOH
-          sudo radosgw-admin zone set --rgw-zone=#{inst['region']}-#{inst['name']} --infile /etc/ceph/#{zone}-zone.json --name client.radosgw.#{inst['region']}-#{inst['name']}
+          radosgw-admin zone set --rgw-zone=#{inst['region']}-#{inst['name']} --infile /etc/ceph/#{zone}-zone.json --name client.radosgw.#{inst['region']}-#{inst['name']}
         EOH
-        # not_if "sudo radosgw-admin zone list --name client.radosgw.#{inst['region']}-#{inst['name']} | grep #{inst['name']}"
+        # not_if "radosgw-admin zone list --name client.radosgw.#{inst['region']}-#{inst['name']} | grep #{inst['name']}"
       end
 
       execute "create-region-defaults-#{inst['region']}" do
         command <<-EOH
-          sudo radosgw-admin region default --rgw-region=#{region} --name client.radosgw.#{inst['region']}-#{inst['name']}
-          sudo radosgw-admin region-map update --rgw-region #{region} --name client.radosgw.#{inst['region']}-#{inst['name']}
+          radosgw-admin region default --rgw-region=#{region} --name client.radosgw.#{inst['region']}-#{inst['name']}
+          radosgw-admin region-map update --rgw-region #{region} --name client.radosgw.#{inst['region']}-#{inst['name']}
         EOH
       end
     end
 
     # execute "update-regionmap-#{inst['name']}" do
     #  command <<-EOH
-    #    sudo radosgw-admin regionmap update --name client.radosgw.#{inst['region']}-#{inst['name']}
+    #    radosgw-admin regionmap update --name client.radosgw.#{inst['region']}-#{inst['name']}
     #  EOH
     # end
 

--- a/recipes/radosgw_non_federated.rb
+++ b/recipes/radosgw_non_federated.rb
@@ -61,7 +61,7 @@ if new_key.to_s.strip.empty?
   new_key = nil if new_key.to_s.strip.length != 40
 end
 execute 'update-ceph-radosgw-secret' do
-  command lazy { "sudo ceph-authtool #{keyring} --name=client.radosgw.gateway --add-key=#{new_key} --cap osd 'allow rwx' --cap mon 'allow rwx'" }
+  command lazy { "ceph-authtool #{keyring} --name=client.radosgw.gateway --add-key=#{new_key} --cap osd 'allow rwx' --cap mon 'allow rwx'" }
   only_if { new_key }
   only_if "test -f #{keyring}"
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive

--- a/recipes/radosgw_users.rb
+++ b/recipes/radosgw_users.rb
@@ -80,12 +80,12 @@ node['ceph']['radosgw']['users'].each do |user|
                          "#{user['secret_key']}"
                        end
 
-          rgw_admin = JSON.parse(`sudo radosgw-admin user create --name client.radosgw.#{inst['region']}-#{inst['name']} --display-name="#{user['name']}" --uid="#{user['uid']}" "#{max_buckets}" --access_key="#{access_key}" --secret="#{secret_key}"`)
+          rgw_admin = JSON.parse(`radosgw-admin user create --name client.radosgw.#{inst['region']}-#{inst['name']} --display-name="#{user['name']}" --uid="#{user['uid']}" "#{max_buckets}" --access_key="#{access_key}" --secret="#{secret_key}"`)
           if user.attribute?('admin_caps') && !user['admin_caps'].empty?
-            rgw_admin_cap = JSON.parse(`sudo radosgw-admin caps add --name client.radosgw.#{inst['region']}-#{inst['name']} --uid="#{user['uid']}" --caps="#{user['admin_caps']}"`)
+            rgw_admin_cap = JSON.parse(`radosgw-admin caps add --name client.radosgw.#{inst['region']}-#{inst['name']} --uid="#{user['uid']}" --caps="#{user['admin_caps']}"`)
           end
         end
-        not_if "sudo radosgw-admin user info --name client.radosgw.#{inst['region']}-#{inst['name']} --uid='#{user['uid']}'"
+        not_if "radosgw-admin user info --name client.radosgw.#{inst['region']}-#{inst['name']} --uid='#{user['uid']}'"
         ignore_failure true
       end
 


### PR DESCRIPTION
If /etc/sudoers contains Defaults requiretty,
the commands fail with the following error:

> sudo: sorry, you must have a tty to run sudo
