### PR TITLE
Support environments without public_network CIDR

### DIFF
--- a/libraries/ceph_chef_helper.rb
+++ b/libraries/ceph_chef_helper.rb
@@ -703,8 +703,8 @@ def ceph_chef_mon_nodes_ip(nodes)
 end
 
 def ceph_chef_mon_node_ip(nodeish)
-  # Note: A valid cidr block MUST exist!
-  mon_ip = ceph_chef_find_node_ip_in_network(node['ceph']['network']['public']['cidr'], nodeish)
+  # Note: A valid cidr block MUST exist! or node['ceph']['config']['global']['public addr'] MUST be populated.
+  mon_ip = ceph_chef_find_node_ip_in_network(node['ceph']['network']['public']['cidr'], nodeish) || nodeish['ceph']['config'].fetch('global', {}).fetch('public addr', nil)
   mon_ip
 end
 


### PR DESCRIPTION
Support environments where public_addr is set and public_network is not
present.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>
(cherry picked from commit 33bc6f1effdcca8f940403f58050c90869b77db7)
(cherry picked from commit 1aea1a1f21cef093d0e6254cb88ae042c51b8a47)