### PR TITLE
Improve file tests.

### DIFF
--- a/recipes/admin_client.rb
+++ b/recipes/admin_client.rb
@@ -24,7 +24,7 @@ execute 'format ceph-admin-secret as keyring' do
   command lazy { "ceph-authtool --create-keyring #{keyring} --name=client.admin --add-key='#{node['ceph']['admin-secret']}' --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *'" }
   creates keyring
   only_if { ceph_chef_admin_secret }
-  not_if "test -f #{keyring}"
+  not_if "test -s #{keyring}"
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
@@ -32,7 +32,7 @@ execute 'gen ceph-admin-secret' do
   command lazy { "ceph-authtool --create-keyring #{keyring} --gen-key -n client.admin --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *'" }
   creates keyring
   not_if { ceph_chef_admin_secret }
-  not_if "test -f #{keyring}"
+  not_if "test -s #{keyring}"
   notifies :create, 'ruby_block[save ceph_chef_admin_secret]', :immediately
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end

--- a/recipes/bootstrap_osd_key.rb
+++ b/recipes/bootstrap_osd_key.rb
@@ -24,8 +24,9 @@ bash 'create-bootstrap-osd-key' do
         --name=client.bootstrap-osd \
         --add-key="$BOOTSTRAP_KEY"
   EOH
+  only_if "test -s /etc/ceph/#{node['ceph']['cluster']}.mon.keyring"
   not_if { ceph_chef_bootstrap_osd_secret }
-  not_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
+  not_if "test -s /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
   notifies :create, 'ruby_block[save_bootstrap_osd]', :immediately
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
@@ -34,7 +35,7 @@ end
 execute 'format bootstrap-osd-secret as keyring' do
   command lazy { "ceph-authtool '/var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring' --create-keyring --name=client.bootstrap-osd --add-key=#{ceph_chef_bootstrap_osd_secret}" }
   only_if { ceph_chef_bootstrap_osd_secret }
-  not_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
+  not_if "test -s /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
@@ -45,7 +46,7 @@ ruby_block 'check_bootstrap_osd' do
   end
   notifies :create, 'ruby_block[save_bootstrap_osd]', :immediately
   not_if { ceph_chef_bootstrap_osd_secret }
-  only_if "test -f /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
+  only_if "test -s /var/lib/ceph/bootstrap-osd/#{node['ceph']['cluster']}.keyring"
 end
 
 # Save the bootstrap-osd secret key to the node attributes. This is typically performed

--- a/recipes/mgr.rb
+++ b/recipes/mgr.rb
@@ -46,7 +46,7 @@ if node['ceph']['version'] != 'hammer' && node['ceph']['mgr']['enable']
   #   user node['ceph']['owner']
   #   group node['ceph']['group']
   #   # only_if { ceph_chef_mgr_secret }
-  #   not_if "test -f #{keyring}"
+  #   not_if "test -s #{keyring}"
   #   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
   # end
   #

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -111,7 +111,7 @@ execute 'format ceph-mon-secret as keyring' do
   user node['ceph']['owner']
   group node['ceph']['group']
   only_if { ceph_chef_mon_secret }
-  not_if "test -f #{keyring}"
+  not_if "test -s #{keyring}"
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
@@ -122,7 +122,7 @@ execute 'generate ceph-mon-secret as keyring' do
   user node['ceph']['owner']
   group node['ceph']['group']
   not_if { ceph_chef_mon_secret }
-  not_if "test -f #{keyring}"
+  not_if "test -s #{keyring}"
   notifies :create, 'ruby_block[save ceph_chef_mon_secret]', :immediately
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
@@ -161,7 +161,7 @@ execute 'ceph-mon mkfs' do
   creates "/var/lib/ceph/mon/#{node['ceph']['cluster']}-#{node['hostname']}/keyring"
   user node['ceph']['owner']
   group node['ceph']['group']
-  not_if "test -f /var/lib/ceph/mon/#{node['ceph']['cluster']}-#{node['hostname']}/keyring"
+  not_if "test -s /var/lib/ceph/mon/#{node['ceph']['cluster']}-#{node['hostname']}/keyring"
 end
 
 ruby_block 'mon-finalize' do

--- a/recipes/mon_keys.rb
+++ b/recipes/mon_keys.rb
@@ -37,7 +37,7 @@ include_recipe 'ceph-chef::bootstrap_osd_key'
 #     ceph_chef_save_bootstrap_rgw_secret(key.delete!("\n"))
 #   end
 #   not_if { ceph_chef_bootstrap_rgw_secret }
-#   only_if "test -f /var/lib/ceph/bootstrap-rgw/#{node['ceph']['cluster']}.keyring"
+#   only_if "test -s /var/lib/ceph/bootstrap-rgw/#{node['ceph']['cluster']}.keyring"
 #   ignore_failure true
 # end
 #
@@ -50,6 +50,6 @@ include_recipe 'ceph-chef::bootstrap_osd_key'
 #     ceph_chef_save_bootstrap_mds_secret(key.delete!("\n"))
 #   end
 #   not_if { ceph_chef_bootstrap_mds_secret }
-#   only_if "test -f /var/lib/ceph/bootstrap-mds/#{node['ceph']['cluster']}.keyring"
+#   only_if "test -s /var/lib/ceph/bootstrap-mds/#{node['ceph']['cluster']}.keyring"
 #   ignore_failure true
 # end

--- a/recipes/radosgw.rb
+++ b/recipes/radosgw.rb
@@ -56,12 +56,12 @@ include_recipe 'ceph-chef::radosgw_civetweb'
 
 execute 'osd-create-key-mon-client-in-directory' do
   command lazy { "ceph-authtool /etc/ceph/#{node['ceph']['cluster']}.mon.keyring --create-keyring --name=mon. --add-key=#{ceph_chef_mon_secret} --cap mon 'allow *'" }
-  not_if "test -f /etc/ceph/#{node['ceph']['cluster']}.mon.keyring"
+  not_if "test -s /etc/ceph/#{node['ceph']['cluster']}.mon.keyring"
 end
 
 execute 'osd-create-key-admin-client-in-directory' do
   command lazy { "ceph-authtool /etc/ceph/#{node['ceph']['cluster']}.client.admin.keyring --create-keyring --name=client.admin --add-key=#{ceph_chef_admin_secret} --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *'" }
-  not_if "test -f /etc/ceph/#{node['ceph']['cluster']}.client.admin.keyring"
+  not_if "test -s /etc/ceph/#{node['ceph']['cluster']}.client.admin.keyring"
 end
 
 # Verifies or sets the correct mode only
@@ -109,7 +109,7 @@ end
 #     ceph-authtool -n "client.radosgw.#{node['hostname']}" --cap osd 'allow rwx' --cap mon 'allow rw' "/etc/ceph/#{node['ceph']['cluster']}.client.radosgw.keyring"
 #     ceph -k "#{base_key}" auth add client.radosgw.gateway -i "/etc/ceph/#{node['ceph']['cluster']}.client.radosgw.keyring"
 #   EOH
-#   not_if "test -f /etc/ceph/#{node['ceph']['cluster']}.client.radosgw.keyring"
+#   not_if "test -s /etc/ceph/#{node['ceph']['cluster']}.client.radosgw.keyring"
 #   notifies :create, 'ruby_block[save radosgw_secret]', :immediately
 # end
 
@@ -124,18 +124,18 @@ end
 #         --name=client.radosgw.#{node['hostname']} \
 #         --add-key="$RGW_KEY"
 #   EOH
-#   not_if "test -f /var/lib/ceph/radosgw/#{node['ceph']['cluster']}-radosgw.#{node['hostname']}/keyring"
+#   not_if "test -s /var/lib/ceph/radosgw/#{node['ceph']['cluster']}-radosgw.#{node['hostname']}/keyring"
 #   notifies :create, 'ruby_block[save radosgw_secret]', :immediately
 # end
 
 # execute 'update rgw keys' do
 #   command "ceph -k /etc/ceph/#{node['ceph']['cluster']}.client.admin.keyring auth add client.radosgw.#{node['hostname']} -i /var/lib/ceph/radosgw/#{node['ceph']['cluster']}-radosgw.#{node['hostname']}/keyring"
-#   only_if {"test -f /var/lib/ceph/radosgw/#{node['ceph']['cluster']}-#{node['hostname']}/keyring"}
+#   only_if {"test -s /var/lib/ceph/radosgw/#{node['ceph']['cluster']}-#{node['hostname']}/keyring"}
 # end
 
 # execute 'set rgw_permissions' do
 #   command lazy { "chmod 0644 /var/lib/ceph/radosgw/#{node['ceph']['cluster']}-radosgw.#{node['hostname']}/keyring" }
-#   only_if "test -f /var/lib/ceph/radosgw/#{node['ceph']['cluster']}-radosgw.#{node['hostname']}/keyring"
+#   only_if "test -s /var/lib/ceph/radosgw/#{node['ceph']['cluster']}-radosgw.#{node['hostname']}/keyring"
 # end
 # End of comment block
 

--- a/recipes/radosgw_federated.rb
+++ b/recipes/radosgw_federated.rb
@@ -78,14 +78,14 @@ if node['ceph']['pools']['radosgw']['federated_enable']
     execute 'update-ceph-radosgw-secret' do
       command lazy { "sudo ceph-authtool #{keyring} --name=client.radosgw.#{inst['region']}-#{inst['name']} --add-key=#{new_key} --cap osd 'allow rwx' --cap mon 'allow rwx'" }
       only_if { !new_key.to_s.strip.empty? }
-      only_if "test -f #{keyring}"
+      only_if "test -s #{keyring}"
       sensitive true if Chef::Resource::Execute.method_defined? :sensitive
     end
 
     execute 'write-ceph-radosgw-secret' do
       command lazy { "sudo ceph-authtool #{keyring} --create-keyring --name=client.radosgw.#{inst['region']}-#{inst['name']} --add-key=#{new_key} --cap osd 'allow rwx' --cap mon 'allow rwx'" }
       only_if { !new_key.to_s.strip.empty? }
-      not_if "test -f #{keyring}"
+      not_if "test -s #{keyring}"
       sensitive true if Chef::Resource::Execute.method_defined? :sensitive
     end
 
@@ -96,7 +96,7 @@ if node['ceph']['pools']['radosgw']['federated_enable']
       EOH
       creates keyring
       not_if { ceph_chef_radosgw_inst_secret("#{inst['region']}-#{inst['name']}") }
-      not_if "test -f #{keyring}"
+      not_if "test -s #{keyring}"
       notifies :create, "ruby_block[save-radosgw-secret-#{inst['name']}]", :immediately
       sensitive true if Chef::Resource::Execute.method_defined? :sensitive
     end
@@ -133,12 +133,12 @@ if node['ceph']['pools']['radosgw']['federated_enable']
     if node['ceph']['pools']['radosgw']['federated_multisite_replication'] == true
       template "/etc/ceph/#{inst['region']}-region.json" do
         source 'radosgw-federated-region.json.erb'
-        not_if "test -f /etc/ceph/#{inst['region']}-region.json"
+        not_if "test -s /etc/ceph/#{inst['region']}-region.json"
       end
 
       template "/etc/ceph/#{inst['region']}-region-map.json" do
         source 'radosgw-federated-region-map.json.erb'
-        not_if "test -f /etc/ceph/#{inst['region']}-region-map.json"
+        not_if "test -s /etc/ceph/#{inst['region']}-region-map.json"
       end
 
       region_file = "/etc/ceph/#{inst['region']}-region.json"
@@ -156,7 +156,7 @@ if node['ceph']['pools']['radosgw']['federated_enable']
             :zone_port => (inst['port']).to_s
           }
         }
-        not_if "test -f /etc/ceph/#{inst['region']}-#{inst['name']}-region.json"
+        not_if "test -s /etc/ceph/#{inst['region']}-#{inst['name']}-region.json"
       end
 
       template "/etc/ceph/#{inst['region']}-#{inst['name']}-region-map.json" do
@@ -169,7 +169,7 @@ if node['ceph']['pools']['radosgw']['federated_enable']
             :zone_port => (inst['port']).to_s
           }
         }
-        not_if "test -f /etc/ceph/#{inst['region']}-#{inst['name']}-region-map.json"
+        not_if "test -s /etc/ceph/#{inst['region']}-#{inst['name']}-region-map.json"
       end
 
       region_file = "/etc/ceph/#{inst['region']}-#{inst['name']}-region.json"
@@ -189,7 +189,7 @@ if node['ceph']['pools']['radosgw']['federated_enable']
             :access_key => ''
           }
         }
-        not_if "test -f /etc/ceph/#{zone}-zone.json"
+        not_if "test -s /etc/ceph/#{zone}-zone.json"
       end
 
       execute "region-set-#{inst['region']}" do

--- a/recipes/radosgw_non_federated.rb
+++ b/recipes/radosgw_non_federated.rb
@@ -63,14 +63,14 @@ end
 execute 'update-ceph-radosgw-secret' do
   command lazy { "sudo ceph-authtool #{keyring} --name=client.radosgw.gateway --add-key=#{new_key} --cap osd 'allow rwx' --cap mon 'allow rwx'" }
   only_if { new_key }
-  only_if "test -f #{keyring}"
+  only_if "test -s #{keyring}"
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
 execute 'write-ceph-radosgw-secret' do
   command lazy { "ceph-authtool #{keyring} --create-keyring --name=client.radosgw.gateway --add-key=#{new_key} --cap osd 'allow rwx' --cap mon 'allow rwx'" }
   only_if { new_key }
-  not_if "test -f #{keyring}"
+  not_if "test -s #{keyring}"
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
@@ -81,7 +81,7 @@ execute 'generate-client-radosgw-secret' do
   EOH
   creates keyring
   not_if { new_key }
-  not_if "test -f #{keyring}"
+  not_if "test -s #{keyring}"
   notifies :create, 'ruby_block[save-radosgw-secret]', :immediately
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end

--- a/recipes/restapi.rb
+++ b/recipes/restapi.rb
@@ -44,7 +44,7 @@ keyring = "/etc/ceph/#{node['ceph']['cluster']}.client.restapi.keyring"
 execute 'write ceph-restapi-secret' do
   command lazy { "ceph-authtool #{keyring} --create-keyring --name=client.restapi --add-key='#{node['ceph']['restapi-secret']}'" }
   only_if { ceph_chef_restapi_secret }
-  not_if "test -f #{keyring}"
+  not_if "test -s #{keyring}"
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
@@ -53,7 +53,7 @@ execute 'gen client-restapi-secret' do
   command lazy { "ceph auth get-or-create client.restapi osd 'allow *' mon 'allow *' -o #{keyring}" }
   creates keyring
   not_if { ceph_chef_restapi_secret }
-  not_if "test -f #{keyring}"
+  not_if "test -s #{keyring}"
   notifies :create, 'ruby_block[save restapi_secret]', :immediately
   sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end

--- a/recipes/rpm.rb
+++ b/recipes/rpm.rb
@@ -42,7 +42,7 @@ yum_repository 'ceph' do
   description "Ceph #{platform_family} #{node['ceph']['version']} #{branch}"
   baseurl node['ceph'][platform_family][branch]['repository']
   gpgkey node['ceph'][platform_family][branch]['repository_key']
-  not_if 'test -f /etc/yum.repos.d/ceph.repo'
+  not_if 'test -s /etc/yum.repos.d/ceph.repo'
   only_if { node['ceph']['repo']['create'] }
 end
 
@@ -51,7 +51,7 @@ package 'hdparm'    # used by ceph-disk activate
 package 'xfsprogs'  # needed by ceph-disk-prepare to format as xfs
 
 package 'redhat-lsb-core' do # lsb-init
-  not_if 'test -f /lib/lsb/init-functions'
+  not_if 'test -s /lib/lsb/init-functions'
 end
 
 if node['platform_family'] == 'rhel' && node['platform_version'].to_f > 6


### PR DESCRIPTION
If a keyring or other file is written out as zero bytes because it ran
too early, then it will not be updated later.

Use 'test -s' instead of 'test -f' or 'test -e', to ensure it's more
than zero bytes.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>
(cherry picked from commit dca21b82f41ad548663009c75f19027fc7e3f649)