### PR TITLE
Fixed Readme and ceph-disk activate if statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Most notably, the configuration does **NOT** need to set the `mon initial member
 
 The other set of attributes that this recipe needs is `node['ceph']['osd']['devices']`, which is an array of OSD definitions, similar to the following:
 
-* {'device' => '/dev/sdb'} - Use a full disk for the OSD, with a small partition for the journal
-* {'type' => 'directory', 'device' => '/src/node/sdb1/ceph'} - Use a directory, and have a small file for the journal
-* {'device' => '/dev/sde', 'dmcrypt' => true} - Store the data encrypted by passing --dmcrypt to `ceph-disk-prepare`
-* {'device' => '/dev/sdc', 'journal' => '/dev/sdd2'} - use a full disk for the OSD with a custom partition for the journal on another device such as an SSD or NMVe
+* {'data' => '/dev/sdb'} - Use a full disk for the OSD, with a small partition for the journal
+* {'type' => 'directory', 'data' => '/src/node/sdb1/ceph'} - Use a directory, and have a small file for the journal
+* {'data' => '/dev/sde', 'dmcrypt' => true} - Store the data encrypted by passing --dmcrypt to `ceph-disk-prepare`
+* {'data' => '/dev/sdc', 'journal' => '/dev/sdd2'} - use a full disk for the OSD with a custom partition for the journal on another device such as an SSD or NMVe
 
 ### Ceph Admin Commands
 

--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -129,7 +129,9 @@ if node['ceph']['osd']['devices']
       code <<-EOH
         is_device=$(echo '#{osd_device['data']}' | egrep '/dev/(([a-z]{3,4}[0-9]$)|(cciss/c[0-9]{1}d[0-9]{1}p[0-9]$))')
         ceph-disk -v prepare --cluster #{node['ceph']['cluster']} #{dmcrypt} --fs-type #{node['ceph']['osd']['fs_type']} #{osd_device['data']} #{osd_device['journal']}
+        ceph-disk list
         if [[ -z $is_device ]]; then
+          echo "Start activating the disk"
           ceph-disk -v activate #{osd_device['data']}#{partitions}
         else
           ceph-disk -v activate #{osd_device['data']}

--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -125,8 +125,8 @@ if node['ceph']['osd']['devices']
     # is_ceph - Does the device contain the default 'ceph data' or 'ceph journal' label
     # The -v option is added to the ceph-disk script so as to get a verbose output if debugging is needed. No other reason.
     # is_ceph=$(parted --script #{osd_device['data']} print | egrep -sq '^ 1.*ceph')
-    execute "ceph-disk-prepare on #{osd_device['data']}" do
-      command <<-EOH
+    bash "ceph-disk-prepare on #{osd_device['data']}" do
+      code <<-EOH
         is_device=$(echo '#{osd_device['data']}' | egrep '/dev/(([a-z]{3,4}[0-9]$)|(cciss/c[0-9]{1}d[0-9]{1}p[0-9]$))')
         ceph-disk -v prepare --cluster #{node['ceph']['cluster']} #{dmcrypt} --fs-type #{node['ceph']['osd']['fs_type']} #{osd_device['data']} #{osd_device['journal']}
         if [[ -z $is_device ]]; then

--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -121,7 +121,7 @@ if node['ceph']['osd']['devices']
     # IMPORTANT: More work needs to be done on solid key management for very high security environments.
     dmcrypt = osd_device['encrypted'] == true ? '--dmcrypt' : ''
 
-    # is_device - Is the device a partition or not
+    # is_device - Is the device a partition or not. empty = not a partition
     # is_ceph - Does the device contain the default 'ceph data' or 'ceph journal' label
     # The -v option is added to the ceph-disk script so as to get a verbose output if debugging is needed. No other reason.
     # is_ceph=$(parted --script #{osd_device['data']} print | egrep -sq '^ 1.*ceph')
@@ -129,7 +129,7 @@ if node['ceph']['osd']['devices']
       command <<-EOH
         is_device=$(echo '#{osd_device['data']}' | egrep '/dev/(([a-z]{3,4}[0-9]$)|(cciss/c[0-9]{1}d[0-9]{1}p[0-9]$))')
         ceph-disk -v prepare --cluster #{node['ceph']['cluster']} #{dmcrypt} --fs-type #{node['ceph']['osd']['fs_type']} #{osd_device['data']} #{osd_device['journal']}
-        if [[ ! -z $is_device ]]; then
+        if [[ -z $is_device ]]; then
           ceph-disk -v activate #{osd_device['data']}#{partitions}
         else
           ceph-disk -v activate #{osd_device['data']}

--- a/recipes/osd_add.rb
+++ b/recipes/osd_add.rb
@@ -51,7 +51,7 @@ if node['ceph']['osd']['add']
       command <<-EOH
         is_device=$(echo '#{osd_device['data']}' | egrep '/dev/(([a-z]{3,4}[0-9]$)|(cciss/c[0-9]{1}d[0-9]{1}p[0-9]$))')
         ceph-disk -v prepare --cluster #{node['ceph']['cluster']} #{dmcrypt} --fs-type #{node['ceph']['osd']['fs_type']} #{osd_device['data']} #{osd_device['journal']}
-        if [[ ! -z $is_device ]]; then
+        if [[ -z $is_device ]]; then
           ceph-disk -v activate #{osd_device['data']}#{partitions}
         else
           ceph-disk -v activate #{osd_device['data']}

--- a/recipes/osd_add.rb
+++ b/recipes/osd_add.rb
@@ -47,8 +47,8 @@ if node['ceph']['osd']['add']
     # is_ceph - Does the device contain the default 'ceph data' or 'ceph journal' label
     # The -v option is added to the ceph-disk script so as to get a verbose output if debugging is needed. No other reason.
     # is_ceph=$(parted --script #{osd_device['data']} print | egrep -sq '^ 1.*ceph')
-    execute "ceph-disk-prepare on #{osd_device['data']}" do
-      command <<-EOH
+    bash "ceph-disk-prepare on #{osd_device['data']}" do
+      code <<-EOH
         is_device=$(echo '#{osd_device['data']}' | egrep '/dev/(([a-z]{3,4}[0-9]$)|(cciss/c[0-9]{1}d[0-9]{1}p[0-9]$))')
         ceph-disk -v prepare --cluster #{node['ceph']['cluster']} #{dmcrypt} --fs-type #{node['ceph']['osd']['fs_type']} #{osd_device['data']} #{osd_device['journal']}
         if [[ -z $is_device ]]; then


### PR DESCRIPTION
1. Readme says 'device' is the key for OSD data device but codes are actually using 'data'.
2. is_device is misleading name but it actually checks if it's a partition as mentioned in the comments. so ceph-disk activate should be executed with `#{partitions}` when is_device is empty = it's not including a partition number.
Also added 2 lines to make debugging easier from chef client log.