### PR TITLE
Allow modification of OSD storage engine

### DIFF
--- a/attributes/osd.rb
+++ b/attributes/osd.rb
@@ -23,6 +23,11 @@ default['ceph']['osd']['init_style'] = node['ceph']['init_style']
 default['ceph']['osd']['dmcrypt'] = false  # By default don't encrypt osds at rest
 default['ceph']['osd']['fs_type'] = 'xfs'  # xfs, ext4, btrfs
 
+# specify the default storage layout to use for OSD
+# use filestore as default as bluestore is not supported by the cookbook yet
+# supported: 'filestore', 'bluestore' if empty default of ceph-disk will be used
+default['ceph']['osd']['type'] = 'filestore'
+
 default['ceph']['osd']['secret_file'] = '/etc/chef/secrets/ceph_chef_osd'
 
 # Defaults for osd pools that are replica pools. Max size is the number of replicas and min is the lowest.

--- a/libraries/ceph_chef_helper.rb
+++ b/libraries/ceph_chef_helper.rb
@@ -491,7 +491,7 @@ def ceph_chef_radosgw_secret
   return node['ceph']['radosgw-secret'] if node['ceph']['radosgw-secret']
   if node['ceph']['encrypted_data_bags']
     secret = Chef::EncryptedDataBagItem.load_secret(node['ceph']['radosgw']['secret_file'])
-    Chef::EncryptedDataBagItem.load('ceph', 'radowgw', secret)['secret']
+    Chef::EncryptedDataBagItem.load('ceph', 'radosgw', secret)['secret']
   elsif !ceph_chef_radosgw_nodes.empty?
     rgw_inst = ceph_chef_radosgw_nodes[0]
     if rgw_inst['ceph']['radosgw-secret']

--- a/recipes/admin_client.rb
+++ b/recipes/admin_client.rb
@@ -52,5 +52,5 @@ end
 
 # Verifies or sets the correct mode only
 file "/etc/ceph/#{node['ceph']['cluster']}.client.admin.keyring" do
-  mode '0644'
+  mode '0640'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,6 +46,7 @@ if node['ceph']['netaddr_install']
 
   chef_gem 'netaddr' do
     action :install
+    version '<2'
     compile_time true
     not_if { File.exist?('/tmp/netaddr-1.5.1.gem') }
   end

--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -121,6 +121,14 @@ if node['ceph']['osd']['devices']
     # IMPORTANT: More work needs to be done on solid key management for very high security environments.
     dmcrypt = osd_device['encrypted'] == true ? '--dmcrypt' : ''
 
+    # set the storage type for the OSD data
+    # if none is specified use the default specified by upstream (currently bluestore)
+    osd_type = if node['ceph']['osd']['type'].eql?('bluestore')
+      '--bluestore'
+    elsif node['ceph']['osd']['type'].eql?('filestore')
+      '--filestore'
+    end
+
     # is_device - Is the device a partition or not
     # is_ceph - Does the device contain the default 'ceph data' or 'ceph journal' label
     # The -v option is added to the ceph-disk script so as to get a verbose output if debugging is needed. No other reason.
@@ -128,7 +136,7 @@ if node['ceph']['osd']['devices']
     execute "ceph-disk-prepare on #{osd_device['data']}" do
       command <<-EOH
         is_device=$(echo '#{osd_device['data']}' | egrep '/dev/(([a-z]{3,4}[0-9]$)|(cciss/c[0-9]{1}d[0-9]{1}p[0-9]$))')
-        ceph-disk -v prepare --cluster #{node['ceph']['cluster']} #{dmcrypt} --fs-type #{node['ceph']['osd']['fs_type']} #{osd_device['data']} #{osd_device['journal']}
+        ceph-disk -v prepare --cluster #{node['ceph']['cluster']} #{dmcrypt} #{osd_type} --fs-type #{node['ceph']['osd']['fs_type']} #{osd_device['data']} #{osd_device['journal']}
         if [[ ! -z $is_device ]]; then
           ceph-disk -v activate #{osd_device['data']}#{partitions}
         else

--- a/recipes/radosgw.rb
+++ b/recipes/radosgw.rb
@@ -66,7 +66,7 @@ end
 
 # Verifies or sets the correct mode only
 file "/etc/ceph/#{node['ceph']['cluster']}.client.admin.keyring" do
-  mode '0644'
+  mode '0640'
 end
 
 # Portion above is the same for Federated and Non-Federated versions.


### PR DESCRIPTION
With the luminous release the new Bluestore engine was added which is used by default.
This cookbook doesn't support block.db or block.WAL management yet so use the legacy engine by default.

2 small further fixes regarding a typo and security.