### PR TITLE
Fix owner of client.admin.keyring file

### DIFF
--- a/recipes/admin_client.rb
+++ b/recipes/admin_client.rb
@@ -52,5 +52,7 @@ end
 
 # Verifies or sets the correct mode only
 file "/etc/ceph/#{node['ceph']['cluster']}.client.admin.keyring" do
+  user node['ceph']['owner']
+  group node['ceph']['group']
   mode '0640'
 end


### PR DESCRIPTION
Previously, this was owned by the user running Chef, rather than the Ceph user